### PR TITLE
Fix to Android 11 scoped storage

### DIFF
--- a/project/android/AndroidManifest.xml
+++ b/project/android/AndroidManifest.xml
@@ -19,9 +19,11 @@
     <uses-permission android:name="com.android.vending.CHECK_LICENSE"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+
     <application android:label="@string/app_name"
                  android:icon="@drawable/ic_launcher"
-                 android:allowBackup="true" android:resizeableActivity="true">
+                 android:allowBackup="true" android:resizeableActivity="true"
+                 android:requestLegacyExternalStorage="true">
         <meta-data android:name="android.app.lib_name"
                    android:value="game" />
         <activity android:name="Kirikiroid2"


### PR DESCRIPTION
This supposed change to the manifest will allow the application to function normally again in Android 11's scoped storage, by opting out of it. Without this change the app is unable to access xp3 files.

Relevant links:

https://developer.android.com/training/data-storage/manage-all-files

https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage

Fixes #116 